### PR TITLE
mm-go-irckit: Print thread id at the beginning of message 

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,7 @@ github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.9 h1:d5US/mDsogSGW37IV293h//ZFaeajb69h+EHFsv2xGg=
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
+github.com/mattn/go-runewidth v0.0.7 h1:Ei8KR0497xHyKJPAv59M1dkC+rOZCMBJ+t3fZ+twI54=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-sqlite3 v1.11.0 h1:LDdKkqtYlom37fkvqs8rMPFKAMe8+SgjbwZ6ex1/A/Q=
 github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
@@ -147,6 +148,7 @@ github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyex
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mreiferson/go-httpclient v0.0.0-20160630210159-31f0106b4474/go.mod h1:OQA4XLvDbMgS8P0CevmM4m9Q3Jq4phKUzcocxuGJ5m8=
 github.com/mrexodia/wray v0.0.0-20160318003008-78a2c1f284ff/go.mod h1:B8jLfIIPn2sKyWr0D7cL2v7tnrDD5z291s2Zypdu89E=
+github.com/muesli/reflow v0.1.0 h1:oQdpLfO56lr5pgLvqD0TcjW85rDjSYSBVdiG1Ch1ddM=
 github.com/muesli/reflow v0.1.0/go.mod h1:I9bWAt7QTg/que/qmUCJBGlj7wEq8OAFBjPNjc6xK4I=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nelsonken/gomf v0.0.0-20180504123937-a9dd2f9deae9/go.mod h1:A5SRAcpTemjGgIuBq6Kic2yHcoeUFWUinOAlMP/i9xo=

--- a/mm-go-irckit/mmuser.go
+++ b/mm-go-irckit/mmuser.go
@@ -313,9 +313,9 @@ func (u *User) handleWsActionPost(rmsg *model.WebSocketEvent) {
 				parentGhost := u.createMMUser(u.mc.GetUser(parentPost.UserId))
 				if len(threadPosts.Posts) == 2 {
 					// first response
-					data.Message = fmt.Sprintf("%s (re @%s: [%s] %s)", data.Message, parentGhost.Nick, data.ParentId[0:6], shortenMessage(parentPost.Message))
+					data.Message = fmt.Sprintf("[%s] %s (re @%s: %s)", data.ParentId[0:6], data.Message, parentGhost.Nick, shortenMessage(parentPost.Message))
 				} else {
-					data.Message = fmt.Sprintf("%s (re @%s: [%s])", data.Message, parentGhost.Nick, data.ParentId[0:6])
+					data.Message = fmt.Sprintf("[%s] %s", data.ParentId[0:6], data.Message)
 				}
 			}
 		}


### PR DESCRIPTION
This way it’s easier to eye the thread at a glance, and there’s less
visual clutter.